### PR TITLE
Allow opts to contain an external logger, otherwise console is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var not = require('whisk/not');
 module.exports = function(opts) {
   var board = new EventEmitter();
   var rooms = board.rooms = new FastMap();
+  var logger = opts.logger || console;
 
   function connect() {
     var peer = new EventEmitter();
@@ -51,7 +52,7 @@ module.exports = function(opts) {
 
           // if the target is unknown, refuse to send
           if (! target) {
-            console.warn('got a to request for id "' + parts[0] + '" but cannot find target');
+            logger.warn('got a to request for id "' + parts[0] + '" but cannot find target');
             return false;
           }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var not = require('whisk/not');
 module.exports = function(opts) {
   var board = new EventEmitter();
   var rooms = board.rooms = new FastMap();
-  var logger = opts.logger || console;
+  var logger = (opts || {}).logger || console;
 
   function connect() {
     var peer = new EventEmitter();


### PR DESCRIPTION
By default, rtc-switch logs to console.
In setups where an external logger is desired (papertrail, logentries & co), opts should allow us to define our own logger, if we don't, then fallback to console (hence unchanged behavior)
