### PR TITLE
Broadcast /leave for non-empty rooms

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var not = require('whisk/not');
 module.exports = function(opts) {
   var board = new EventEmitter();
   var rooms = board.rooms = new FastMap();
+  var logger = opts.logger || console;
 
   function connect() {
     var peer = new EventEmitter();
@@ -51,7 +52,7 @@ module.exports = function(opts) {
 
           // if the target is unknown, refuse to send
           if (! target) {
-            console.warn('got a to request for id "' + parts[0] + '" but cannot find target');
+            logger.warn('got a to request for id "' + parts[0] + '" but cannot find target');
             return false;
           }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var not = require('whisk/not');
 module.exports = function(opts) {
   var board = new EventEmitter();
   var rooms = board.rooms = new FastMap();
-  var logger = opts.logger || console;
+  var logger = (opts || {}).logger || console;
 
   function connect() {
     var peer = new EventEmitter();

--- a/index.js
+++ b/index.js
@@ -149,6 +149,11 @@ module.exports = function(opts) {
       if (peer.room.members.length === 0) {
         board.emit('room:destroy', peer.room.name);
         rooms.delete(peer.room.name);
+      } else {
+        logger.debug('/leave from ' + peer.id + ' in non empty room');
+        peer.room.members.forEach(function(member) {
+          member.emit('data', '/leave|' + peer.id + '|{"id":' + peer.id + ',"room:"' + peer.room.name + '}');
+        });
       }
 
       peer.room = undefined;


### PR DESCRIPTION
On the main rtc.io page (http://rtc.io/signalling-protocol.html), the protocol asks us to "issue an appropriate /leave message if the client has not issued one already."
When we receive a leave and it doesn't result in an empty room, properly broadcast the /leave message

Requires previous merge request (logger)
https://github.com/rtc-io/rtc-switch/pull/3
